### PR TITLE
Allow anonymous rule changed.

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,21 +21,23 @@ var (
 )
 
 func main() {
-	flag.StringVar(&hmacKey, "signing-key",
+	flag.StringVar(&hmacKey, "k",
 		lookupEnv("BOUNCER_SIGNING_KEY", ""),
 		"symmetric signing key to validate tokens")
 
-	flag.StringVar(&configPath, "config-path",
+	flag.StringVar(&configPath, "p",
 		lookupEnv("BOUNCER_CONFIG_PATH", configPath),
 		fmt.Sprintf("Config YAML path, default = %s", configPath))
 
-	flag.StringVar(&upstreamURL, "upstream-url",
+	flag.StringVar(&upstreamURL, "u",
 		lookupEnv("BOUNCER_UPSTREAM_URL", ""),
 		"URL to be called when the request is authorized")
 
-	flag.StringVar(&listenAddress, "listen-address",
+	flag.StringVar(&listenAddress, "l",
 		lookupEnv("BOUNCER_LISTEN_ADDRESS", listenAddress),
 		fmt.Sprintf("listen address, default = %s", listenAddress))
+
+	flag.Parse()
 
 	// parse upstream URL
 	parsedURL, err := url.Parse(upstreamURL)
@@ -68,7 +70,7 @@ func main() {
 
 	http.HandleFunc("/", server.Proxy)
 
-	log.Printf("Bouncer (%s) starting...", version)
+	log.Printf("Bouncer [%s] started.", version)
 	defer log.Printf("Bouncer shut down.")
 
 	err = http.ListenAndServe(listenAddress, nil)

--- a/services/authorizer.go
+++ b/services/authorizer.go
@@ -129,13 +129,6 @@ func (a AuthorizerImpl) IsAnonymousAllowed(matchedPolicies []models.RoutePolicy)
 
 			if wc1 < wc2 { // then by decreasing number of wildcards
 				return true
-			} else if wc1 == wc2 {
-				dwc1 := strings.Count(p1, "**")
-				dwc2 := strings.Count(p2, "**")
-
-				if dwc1 < dwc2 { // then by decreasing number of double wildcards
-					return true
-				}
 			}
 		}
 		return false

--- a/services/authorizer_test.go
+++ b/services/authorizer_test.go
@@ -276,7 +276,7 @@ func Test_AuthorizerImpl_IsAnonymousAllowed(t *testing.T) {
 		want            bool
 	}{
 		{
-			name:            "empty config",
+			name:            "no matches",
 			matchedPolicies: []models.RoutePolicy{},
 			want:            false,
 		},
@@ -291,24 +291,76 @@ func Test_AuthorizerImpl_IsAnonymousAllowed(t *testing.T) {
 			want:            false,
 		},
 		{
-			name: "one allow one disallow",
+			name: "allow more specific - wildcard",
 			matchedPolicies: []models.RoutePolicy{
-				{AllowAnonymous: true},
-				{AllowAnonymous: false},
+				{
+					Path:           "/users/**",
+					AllowAnonymous: false,
+				},
+				{
+					Path:           "/users/register",
+					AllowAnonymous: true,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "disallow more specific - wildcard",
+			matchedPolicies: []models.RoutePolicy{
+				{
+					Path:           "/**",
+					AllowAnonymous: true,
+				},
+				{
+					Path:           "/billing",
+					AllowAnonymous: false,
+				},
 			},
 			want: false,
 		},
 		{
-			name: "both allow",
+			name: "allow more specific - path length",
 			matchedPolicies: []models.RoutePolicy{
+				{
+					Path:           "/users/**",
+					AllowAnonymous: false,
+				},
+				{
+					Path:           "/users/*/public",
+					AllowAnonymous: true,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "disallow more specific - path length",
+			matchedPolicies: []models.RoutePolicy{
+				{
+					Path:           "/**",
+					AllowAnonymous: true,
+				},
+				{
+					Path:           "/users/**",
+					AllowAnonymous: false,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "multiple allow",
+			matchedPolicies: []models.RoutePolicy{
+				{AllowAnonymous: true},
+				{AllowAnonymous: true},
 				{AllowAnonymous: true},
 				{AllowAnonymous: true},
 			},
 			want: true,
 		},
 		{
-			name: "both disallow",
+			name: "multiple disallow",
 			matchedPolicies: []models.RoutePolicy{
+				{AllowAnonymous: false},
+				{AllowAnonymous: false},
 				{AllowAnonymous: false},
 				{AllowAnonymous: false},
 			},

--- a/services/authorizer_test.go
+++ b/services/authorizer_test.go
@@ -281,14 +281,24 @@ func Test_AuthorizerImpl_IsAnonymousAllowed(t *testing.T) {
 			want:            false,
 		},
 		{
-			name:            "single allow",
-			matchedPolicies: []models.RoutePolicy{{AllowAnonymous: true}},
-			want:            true,
+			name: "single allow",
+			matchedPolicies: []models.RoutePolicy{
+				{
+					Path:           "/",
+					AllowAnonymous: true,
+				},
+			},
+			want: true,
 		},
 		{
-			name:            "single disallow",
-			matchedPolicies: []models.RoutePolicy{{AllowAnonymous: false}},
-			want:            false,
+			name: "single disallow",
+			matchedPolicies: []models.RoutePolicy{
+				{
+					Path:           "/",
+					AllowAnonymous: false,
+				},
+			},
+			want: false,
 		},
 		{
 			name: "allow more specific - wildcard",
@@ -343,26 +353,6 @@ func Test_AuthorizerImpl_IsAnonymousAllowed(t *testing.T) {
 					Path:           "/users/**",
 					AllowAnonymous: false,
 				},
-			},
-			want: false,
-		},
-		{
-			name: "multiple allow",
-			matchedPolicies: []models.RoutePolicy{
-				{AllowAnonymous: true},
-				{AllowAnonymous: true},
-				{AllowAnonymous: true},
-				{AllowAnonymous: true},
-			},
-			want: true,
-		},
-		{
-			name: "multiple disallow",
-			matchedPolicies: []models.RoutePolicy{
-				{AllowAnonymous: false},
-				{AllowAnonymous: false},
-				{AllowAnonymous: false},
-				{AllowAnonymous: false},
 			},
 			want: false,
 		},

--- a/services/authorizer_test.go
+++ b/services/authorizer_test.go
@@ -332,12 +332,12 @@ func Test_AuthorizerImpl_IsAnonymousAllowed(t *testing.T) {
 			name: "allow more specific - path length",
 			matchedPolicies: []models.RoutePolicy{
 				{
-					Path:           "/users/**",
-					AllowAnonymous: false,
-				},
-				{
 					Path:           "/users/*/public",
 					AllowAnonymous: true,
+				},
+				{
+					Path:           "/users/**",
+					AllowAnonymous: false,
 				},
 			},
 			want: true,

--- a/services/config_parser.go
+++ b/services/config_parser.go
@@ -18,7 +18,7 @@ type ConfigParser interface {
 type YamlConfigParser struct{}
 
 // ParseConfig implements config parsing from YAML files
-func (_ YamlConfigParser) ParseConfig(reader io.Reader) (*models.Config, error) {
+func (YamlConfigParser) ParseConfig(reader io.Reader) (*models.Config, error) {
 	decoder := yaml.NewDecoder(reader)
 
 	cfg := models.Config{}

--- a/services/server.go
+++ b/services/server.go
@@ -64,11 +64,12 @@ func (s Server) Proxy(writer http.ResponseWriter, request *http.Request) {
 	}
 
 	if failedClaim != "" {
-		log.Printf("[%v] Check for claim %s failed.", requestID, failedClaim)
+		log.Printf("[%v] Check for claim \"%s\" failed.", requestID, failedClaim)
 		writer.WriteHeader(http.StatusForbidden)
 		return
 	}
 
 	// allow
+	log.Printf("[%v] Authorized.", requestID)
 	s.Upstream.ServeHTTP(writer, request)
 }


### PR DESCRIPTION
Allow anonymous is now checked from the most specific route policy that matches the request.
Minor fixes and changes in plumbing and logs.