### PR TITLE
Integration test added for employee example.

### DIFF
--- a/services/authorizer.go
+++ b/services/authorizer.go
@@ -73,7 +73,7 @@ func (a AuthorizerImpl) Authorize(policyNames []string, claims map[string]interf
 			found := false
 			for _, val := range arr {
 				for _, cfgVal := range cp.Values {
-					if val == cfgVal {
+					if claimEquals(val, cfgVal) {
 						found = true
 						break
 					}
@@ -95,7 +95,7 @@ func (a AuthorizerImpl) Authorize(policyNames []string, claims map[string]interf
 		// if the matching claim is not an array, check direct equality with expectation
 		found := false
 		for _, cfgVal := range cp.Values {
-			if claims[cp.Claim] == cfgVal {
+			if claimEquals(claims[cp.Claim], cfgVal) {
 				found = true
 				break
 			}
@@ -107,6 +107,10 @@ func (a AuthorizerImpl) Authorize(policyNames []string, claims map[string]interf
 	}
 
 	return failedClaim, nil
+}
+
+func claimEquals(claim interface{}, expectation string) bool {
+	return fmt.Sprintf("%v", claim) == expectation
 }
 
 // IsAnonymousAllowed checks if the most specific policy allows anonymous access

--- a/services/authorizer_test.go
+++ b/services/authorizer_test.go
@@ -89,7 +89,7 @@ func Test_AuthorizerImpl_Authorize(t *testing.T) {
 			wantErr:         false,
 		},
 		{
-			name: "claim value matches",
+			name: "claim value matches - string",
 			claimPolicies: map[string][]models.ClaimRequirement{
 				"NamedJohn": {
 					models.ClaimRequirement{
@@ -102,6 +102,44 @@ func Test_AuthorizerImpl_Authorize(t *testing.T) {
 				policyNames: []string{"NamedJohn"},
 				claims: map[string]interface{}{
 					"name": "John",
+				},
+			},
+			wantFailedClaim: "",
+			wantErr:         false,
+		},
+		{
+			name: "claim value matches - int",
+			claimPolicies: map[string][]models.ClaimRequirement{
+				"Founder": {
+					models.ClaimRequirement{
+						Claim:  "employee_number",
+						Values: []string{"1"},
+					},
+				},
+			},
+			args: args{
+				policyNames: []string{"Founder"},
+				claims: map[string]interface{}{
+					"employee_number": 1,
+				},
+			},
+			wantFailedClaim: "",
+			wantErr:         false,
+		},
+		{
+			name: "claim value matches - bool",
+			claimPolicies: map[string][]models.ClaimRequirement{
+				"CanDoStuff": {
+					models.ClaimRequirement{
+						Claim:  "do_stuff",
+						Values: []string{"true"},
+					},
+				},
+			},
+			args: args{
+				policyNames: []string{"CanDoStuff"},
+				claims: map[string]interface{}{
+					"do_stuff": true,
 				},
 			},
 			wantFailedClaim: "",

--- a/services/route_matcher.go
+++ b/services/route_matcher.go
@@ -29,8 +29,8 @@ func NewRouteMatcher(routePolicies []models.RoutePolicy) *RouteMatcherImpl {
 func (g RouteMatcherImpl) MatchRoutePolicies(path string, method string) ([]models.RoutePolicy, error) {
 	matches := make([]models.RoutePolicy, 0)
 	for _, rp := range g.routePolicies {
-		normalizedPath := strings.Trim(path, " \t\n/")
-		normalizedPolicyPath := strings.Trim(rp.Path, " \t\n/")
+		normalizedPath := "/" + strings.Trim(path, " \t\n/") + "/"
+		normalizedPolicyPath := "/" + strings.Trim(rp.Path, " \t\n/") + "/"
 
 		g, err := glob.Compile(normalizedPolicyPath, '/')
 		if err != nil {


### PR DESCRIPTION
Fixed route matcher not matching request paths without a trailing slash.
Fixed authorizer not being able to equate non-string-valued claims with the configured counterparts.